### PR TITLE
[pmon] Delay platform monitoring service on boot

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -21,7 +21,7 @@
                    ("database", "enabled", false, "disabled"),
                    ("dhcp_relay", "enabled", false, "enabled"),
                    ("lldp", "enabled", false, "enabled"),
-                   ("pmon", "enabled", false, "enabled"),
+                   ("pmon", "enabled", true, "enabled"),
                    ("radv", "enabled", false, "enabled"),
                    ("snmp", "enabled", true, "enabled"),
                    ("swss", "enabled", false, "enabled"),

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -5,6 +5,7 @@ After=updategraph.service
 {% if sonic_asic_platform == 'mellanox' %}
 After=syncd.service
 {% endif %}
+Conflicts=pmon.timer
 Before=ntp-config.service
 StartLimitIntervalSec=1200
 StartLimitBurst=3
@@ -17,5 +18,3 @@ ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 Restart=always
 RestartSec=30
 
-[Install]
-WantedBy=multi-user.target

--- a/files/build_templates/pmon.timer
+++ b/files/build_templates/pmon.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Delays platform monitoring container until SONiC has started
+Conflicts=pmon.service
+
+[Timer]
+OnUnitActiveSec=0 sec
+OnBootSec=3min 30 sec
+Unit=pmon.service
+
+[Install]
+WantedBy=timers.target

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -483,6 +483,9 @@ sudo cp $BUILD_TEMPLATES/mgmt-framework.timer $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_S
 echo "mgmt-framework.timer" | sudo tee -a $GENERATED_SERVICE_FILE
 {% endif %}
 
+sudo cp $BUILD_TEMPLATES/pmon.timer $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+echo "pmon.timer" | sudo tee -a $GENERATED_SERVICE_FILE
+
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get purge -y python-dev
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean -y
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get autoremove -y

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -129,9 +129,9 @@ start() {
 
 wait() {
     if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
-        debug "Starting pmon service..."
-        /bin/systemctl start pmon
-        debug "Started pmon service"
+        debug "Starting pmon timer unit..."
+        /bin/systemctl start pmon.timer
+        debug "Started pmon timer unit"
     fi
     /usr/bin/${SERVICE}.sh wait $DEV
 }
@@ -159,7 +159,7 @@ stop() {
         debug "${TYPE} shutdown syncd process ..."
         /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_shutdown --${TYPE}
 
-        # wait until syncd quits gracefully or force syncd to exit after 
+        # wait until syncd quits gracefully or force syncd to exit after
         # waiting for 20 seconds
         start_in_secs=${SECONDS}
         end_in_secs=${SECONDS}
@@ -171,7 +171,7 @@ stop() {
         done
 
         if [[ $((end_in_secs - start_in_secs)) -gt $timer_threshold ]]; then
-            debug "syncd process in container syncd$DEV did not exit gracefully" 
+            debug "syncd process in container syncd$DEV did not exit gracefully"
         fi
 
         /usr/bin/docker exec -i syncd$DEV /bin/sync


### PR DESCRIPTION
Added pmon.timer and modified syncd.sh script to start pmon.timer
instead of pmon.service.
pmon.timer can start pmon.service in two scenarios:
- on boot timer expires (~3 min after boot)
- if pmon.service was active before and now stopped, the timer will
  imidiatelly start pmon.service
In order to implemente above two cases pmon.timer and pmon.service
are configured as mutually exclusive units.
This siginifcantly improves fast-reboot down
time by freeing the CPU and platform/asic from polling platform data.
The improvement is shown to give around 8 sec.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
