### PR TITLE
[sonic-cfggen] store jinja2 cache in log level db.

### DIFF
--- a/src/sonic-config-engine/redis_bcc.py
+++ b/src/sonic-config-engine/redis_bcc.py
@@ -1,5 +1,7 @@
 import jinja2
 
+from base64 import b64encode, b64decode
+
 class RedisBytecodeCache(jinja2.BytecodeCache):
     """ A bytecode cache for jinja2 template that stores bytecode in Redis """
 
@@ -8,19 +10,20 @@ class RedisBytecodeCache(jinja2.BytecodeCache):
     def __init__(self, client):
         self._client = client
         try:
-            self._client.connect(self._client.STATE_DB, retry_on=False)
+            self._client.connect(self._client.LOGLEVEL_DB, retry_on=False)
         except Exception:
             self._client = None
 
     def load_bytecode(self, bucket):
         if self._client is None:
             return
-        code = self._client.get(self._client.STATE_DB, self.REDIS_HASH, bucket.key)
+        code = self._client.get(self._client.LOGLEVEL_DB, self.REDIS_HASH, bucket.key)
         if code is not None:
-            bucket.bytecode_from_string(code)
+            bucket.bytecode_from_string(b64decode(code))
 
     def dump_bytecode(self, bucket):
         if self._client is None:
             return
-        self._client.set(self._client.STATE_DB, self.REDIS_HASH, bucket.key, bucket.bytecode_to_string())
+        self._client.set(self._client.LOGLEVEL_DB, self.REDIS_HASH,
+                         bucket.key, b64encode(bucket.bytecode_to_string()))
 


### PR DESCRIPTION
This PR makes two changes:
    - Store Jinja2 cache in LOGLEVEL DB instead of STATE DB
    - Store bytecode cache encoded in base64

Tested with the following command: "redis-dump -d 3 -k JINJA2_CACHE"

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
