### PR TITLE
[hostcfgd] Configure service auto-restart in hostcfgd.

### DIFF
--- a/dockers/docker-database/supervisord.conf.j2
+++ b/dockers/docker-database/supervisord.conf.j2
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name database
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=50
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name dhcp_relay
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=50
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name bgp
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-fpm-gobgp/supervisord.conf
+++ b/dockers/docker-fpm-gobgp/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name bgp
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-fpm-quagga/supervisord.conf
+++ b/dockers/docker-fpm-quagga/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name bgp
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-lldp/supervisord.conf.j2
+++ b/dockers/docker-lldp/supervisord.conf.j2
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name lldp
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-nat/supervisord.conf
+++ b/dockers/docker-nat/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name nat
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=100
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name swss
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=100
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name pmon
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
+++ b/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-script]
-command=/usr/bin/supervisor-proc-exit-listener --container-name radv
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-sflow/supervisord.conf
+++ b/dockers/docker-sflow/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name sflow
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-snmp/supervisord.conf
+++ b/dockers/docker-snmp/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=50
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name snmp
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/dockers/docker-sonic-restapi/supervisord.conf
+++ b/dockers/docker-sonic-restapi/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name restapi
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=false

--- a/dockers/docker-sonic-telemetry/supervisord.conf
+++ b/dockers/docker-sonic-telemetry/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=50
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name telemetry
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=false

--- a/dockers/docker-teamd/supervisord.conf
+++ b/dockers/docker-teamd/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=50
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name teamd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/files/build_templates/dhcp_relay.service.j2
+++ b/files/build_templates/dhcp_relay.service.j2
@@ -11,7 +11,6 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{ docker_container_name }}.sh start
 ExecStart=/usr/bin/{{ docker_container_name }}.sh wait
 ExecStop=/usr/bin/{{ docker_container_name }}.sh stop
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/nat.service.j2
+++ b/files/build_templates/nat.service.j2
@@ -11,7 +11,6 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/per_namespace/bgp.service.j2
+++ b/files/build_templates/per_namespace/bgp.service.j2
@@ -14,7 +14,6 @@ ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instan
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
 
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/per_namespace/database.service.j2
+++ b/files/build_templates/per_namespace/database.service.j2
@@ -17,7 +17,6 @@ User=root
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/per_namespace/lldp.service.j2
+++ b/files/build_templates/per_namespace/lldp.service.j2
@@ -15,7 +15,6 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/per_namespace/swss.service.j2
+++ b/files/build_templates/per_namespace/swss.service.j2
@@ -22,7 +22,6 @@ Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStartPre=/usr/local/bin/swss.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/swss.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/swss.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/per_namespace/teamd.service.j2
+++ b/files/build_templates/per_namespace/teamd.service.j2
@@ -12,7 +12,6 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -14,7 +14,6 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/radv.service.j2
+++ b/files/build_templates/radv.service.j2
@@ -11,7 +11,6 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/local/bin/{{ docker_container_name }}.sh start
 ExecStart=/usr/local/bin/{{ docker_container_name }}.sh wait
 ExecStop=/usr/local/bin/{{ docker_container_name }}.sh stop
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/restapi.service.j2
+++ b/files/build_templates/restapi.service.j2
@@ -9,7 +9,6 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/sflow.service.j2
+++ b/files/build_templates/sflow.service.j2
@@ -11,7 +11,6 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/share_image/database.service.j2
+++ b/files/build_templates/share_image/database.service.j2
@@ -13,7 +13,6 @@ User=root
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start chassisdb
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait chassisdb
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop chassisdb
-Restart=always
 RestartSec=30
 
 [Install]

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -12,6 +12,5 @@ StartLimitBurst=3
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-Restart=always
 RestartSec=30
 

--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -11,6 +11,5 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-Restart=always
 RestartSec=30
 

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -3,7 +3,6 @@
 
 import ast
 import os
-import sys
 import subprocess
 import syslog
 import copy
@@ -42,6 +41,139 @@ def obfuscate(data):
     else:
         return data
 
+
+class Feature(object):
+    """ Represents a feature configuration from CONFIG DB data. """
+
+    def __init__(self, feature_name, feature_cfg):
+        self.name = feature_name
+        self.state = feature_cfg.get('state')
+        self.auto_restart = feature_cfg.get('auto_restart', 'disabled')
+        self.has_timer = ast.literal_eval(feature_cfg.get('has_timer', 'False'))
+        self.has_global_scope = ast.literal_eval(feature_cfg.get('has_global_scope', 'True'))
+        self.has_per_asic_scope = ast.literal_eval(feature_cfg.get('has_per_asic_scope', 'False'))
+
+
+class FeatureHandler(object):
+    """ Handles FEATURE table updates. """
+
+    SYSTEMD_SERVICE_CONF_D = '/etc/systemd/system/{}.service.d/'
+
+    def __init__(self, config_db):
+        self._config_db = config_db
+        self._cached_config = {}
+        self.is_multi_npu = device_info.is_multi_npu()
+
+    def handle(self, feature_name, feature_cfg):
+        feature = Feature(feature_name, feature_cfg)
+        if feature.state is None:
+            syslog.syslog(syslog.LOG_WARNING, "Enable state of feature '{}' is None".format(feature_name))
+            return
+
+        self._cached_config.setdefault(feature_name, Feature(feature_name, {}))
+
+        # Change auto-restart configuration first.
+        # If service reached failed state before this configuration applies (e.g. on boot)
+        # the next called self.update_feature_state will start it again. If it will fail
+        # again the auto restart will kick-in. Another order may leave it in failed state
+        # and not auto restart.
+        if self._cached_config[feature_name].auto_restart != feature.auto_restart:
+            self._cached_config[feature_name].auto_restart = feature.auto_restart
+            self.update_feature_auto_restart(feature)
+
+        # Enable/disable the container service if the feature state was changed from its previous state.
+        if self._cached_config[feature_name].state != feature.state:
+            self._cached_config[feature_name].state = feature.state
+            self.update_feature_state(feature)
+
+    def update_all_features_config(self):
+        feature_table = self._config_db.get_table('FEATURE')
+        for feature_name in feature_table.keys():
+            if not feature_name:
+                syslog.syslog(syslog.LOG_WARNING, "Feature is None")
+                continue
+
+            self.handle(feature_name, feature_table[feature_name])
+
+    def update_feature_state(self, feature):
+        # Create feature name suffix depending feature is running in host or namespace or in both
+        feature_name_suffix_list = self._get_feature_name_suffixes(feature)
+
+        if not feature_name_suffix_list:
+            syslog.syslog(syslog.LOG_ERR, "Feature '{}' service not available"
+                          .format(feature.name))
+
+        feature_suffixes = self._get_feature_suffixes(feature)
+
+        if feature.state == "enabled":
+            start_cmds = []
+            for feature_name_suffix in feature_name_suffix_list:
+                for suffix in feature_suffixes:
+                    start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name_suffix, suffix))
+                # If feature has timer associated with it, start/enable corresponding systemd .timer unit
+                # otherwise, start/enable corresponding systemd .service unit
+                start_cmds.append("sudo systemctl enable {}.{}".format(feature_name_suffix, feature_suffixes[-1]))
+                start_cmds.append("sudo systemctl start {}.{}".format(feature_name_suffix, feature_suffixes[-1]))
+                for cmd in start_cmds:
+                    syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
+                    try:
+                        subprocess.check_call(cmd, shell=True)
+                    except subprocess.CalledProcessError as err:
+                        syslog.syslog(syslog.LOG_ERR, "'{}' failed. RC: {}, output: {}"
+                                      .format(err.cmd, err.returncode, err.output))
+                        syslog.syslog(syslog.LOG_ERR, "Feature '{}.{}' failed to be  enabled and started"
+                                      .format(feature.name, feature_suffixes[-1]))
+                        return
+            syslog.syslog(syslog.LOG_INFO, "Feature '{}.{}' is enabled and started"
+                          .format(feature.name, feature_suffixes[-1]))
+        elif feature.state == "disabled":
+            stop_cmds = []
+            for feature_name_suffix in feature_name_suffix_list:
+                for suffix in reversed(feature_suffixes):
+                    stop_cmds.append("sudo systemctl stop {}.{}".format(feature_name_suffix, suffix))
+                    stop_cmds.append("sudo systemctl disable {}.{}".format(feature_name_suffix, suffix))
+                    stop_cmds.append("sudo systemctl mask {}.{}".format(feature_name_suffix, suffix))
+                for cmd in stop_cmds:
+                    syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
+                    try:
+                        subprocess.check_call(cmd, shell=True)
+                    except subprocess.CalledProcessError as err:
+                        syslog.syslog(syslog.LOG_ERR, "'{}' failed. RC: {}, output: {}"
+                                      .format(err.cmd, err.returncode, err.output))
+                        syslog.syslog(syslog.LOG_ERR, "Feature '{}' failed to be stopped "
+                                                      "and disabled".format(feature.name))
+                        return
+            syslog.syslog(syslog.LOG_INFO, "Feature '{}' is stopped and disabled".format(feature.name))
+        else:
+            syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}'"
+                          .format(feature.state, feature.name))
+
+    def update_feature_auto_restart(self, feature):
+        restart_config = "always" if feature.auto_restart == "enabled" else "no"
+        service_conf = "[Service]\nRestart={}\n".format(restart_config)
+        feature_name_suffix_list = self._get_feature_name_suffixes(feature)
+        for service_name in feature_name_suffix_list:
+            dir_name = self.SYSTEMD_SERVICE_CONF_D.format(service_name)
+            if not os.path.exists(dir_name):
+                os.mkdir(dir_name)
+            with open(os.path.join(dir_name, 'auto_restart.conf'), 'w') as cfgfile:
+                cfgfile.write(service_conf)
+
+        try:
+            subprocess.check_call("sudo systemctl daemon-reload", shell=True)
+        except subprocess.CalledProcessError as err:
+            syslog.syslog(syslog.LOG_ERR, "'{}' failed. RC: {}, output: {}"
+                          .format(err.cmd, err.returncode, err.output))
+            syslog.syslog(syslog.LOG_ERR, "Feature '{}' failed to configure auto_restart".format(feature.name))
+            return
+
+    def _get_feature_name_suffixes(self, feature):
+        return (([feature.name] if feature.has_global_scope or not self.is_multi_npu else []) +
+               ([(feature.name + '@' + str(asic_inst)) for asic_inst in range(device_info.get_num_npus())
+                if feature.has_per_asic_scope and self.is_multi_npu]))
+
+    def _get_feature_suffixes(self, feature):
+        return ["service"] + (["timer"] if feature.has_timer else [])
 
 
 class Iptables(object):
@@ -241,85 +373,7 @@ class HostConfigDaemon:
         lpbk_table = self.config_db.get_table('LOOPBACK_INTERFACE')
         self.iptables = Iptables()
         self.iptables.load(lpbk_table)
-        self.is_multi_npu = device_info.is_multi_npu()
-        # Cache the values of 'state' field in 'FEATURE' table of each container
-        self.cached_feature_states = {}
-
-    def update_feature_state(self, feature_name, state, feature_table):
-        has_timer = ast.literal_eval(feature_table[feature_name].get('has_timer', 'False'))
-        has_global_scope = ast.literal_eval(feature_table[feature_name].get('has_global_scope', 'True'))
-        has_per_asic_scope = ast.literal_eval(feature_table[feature_name].get('has_per_asic_scope', 'False'))
-
-        # Create feature name suffix depending feature is running in host or namespace or in both 
-        feature_name_suffix_list = (([feature_name] if has_global_scope or not self.is_multi_npu else []) +
-                                   ([(feature_name + '@' + str(asic_inst)) for asic_inst in range(device_info.get_num_npus()) 
-                                    if has_per_asic_scope and self.is_multi_npu]))
-
-        if not feature_name_suffix_list:
-            syslog.syslog(syslog.LOG_ERR, "Feature '{}' service not available"
-                          .format(feature_name))
-
-        feature_suffixes = ["service"] + (["timer"] if has_timer else [])
-
-        if state == "enabled":
-            start_cmds = []
-            for feature_name_suffix in feature_name_suffix_list:
-                for suffix in feature_suffixes:
-                    start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name_suffix, suffix))
-                # If feature has timer associated with it, start/enable corresponding systemd .timer unit
-                # otherwise, start/enable corresponding systemd .service unit
-                start_cmds.append("sudo systemctl enable {}.{}".format(feature_name_suffix, feature_suffixes[-1]))
-                start_cmds.append("sudo systemctl start {}.{}".format(feature_name_suffix, feature_suffixes[-1]))
-                for cmd in start_cmds:
-                    syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
-                    try:
-                        subprocess.check_call(cmd, shell=True)
-                    except subprocess.CalledProcessError as err:
-                        syslog.syslog(syslog.LOG_ERR, "'{}' failed. RC: {}, output: {}"
-                                      .format(err.cmd, err.returncode, err.output))
-                        syslog.syslog(syslog.LOG_ERR, "Feature '{}.{}' failed to be  enabled and started"
-                                      .format(feature_name, feature_suffixes[-1]))
-                        return
-            syslog.syslog(syslog.LOG_INFO, "Feature '{}.{}' is enabled and started"
-                          .format(feature_name, feature_suffixes[-1]))
-        elif state == "disabled":
-            stop_cmds = []
-            for feature_name_suffix in feature_name_suffix_list:
-                for suffix in reversed(feature_suffixes):
-                    stop_cmds.append("sudo systemctl stop {}.{}".format(feature_name_suffix, suffix))
-                    stop_cmds.append("sudo systemctl disable {}.{}".format(feature_name_suffix, suffix))
-                    stop_cmds.append("sudo systemctl mask {}.{}".format(feature_name_suffix, suffix))
-                for cmd in stop_cmds:
-                    syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
-                    try:
-                        subprocess.check_call(cmd, shell=True)
-                    except subprocess.CalledProcessError as err:
-                        syslog.syslog(syslog.LOG_ERR, "'{}' failed. RC: {}, output: {}"
-                                      .format(err.cmd, err.returncode, err.output))
-                        syslog.syslog(syslog.LOG_ERR, "Feature '{}' failed to be stopped and disabled".format(feature_name))
-                        return
-            syslog.syslog(syslog.LOG_INFO, "Feature '{}' is stopped and disabled".format(feature_name))
-        else:
-            syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}'"
-                          .format(state, feature_name))
-
-
-    def update_all_feature_states(self):
-        feature_table = self.config_db.get_table('FEATURE')
-        for feature_name in feature_table.keys():
-            if not feature_name:
-                syslog.syslog(syslog.LOG_WARNING, "Feature is None")
-                continue
-
-            state = feature_table[feature_name]['state']
-            if not state:
-                syslog.syslog(syslog.LOG_WARNING, "Eanble state of feature '{}' is None".format(feature_name))
-                continue
-
-            # Store the initial value of 'state' field in 'FEATURE' table of a specific container
-            self.cached_feature_states[feature_name] = state
-
-            self.update_feature_state(feature_name, state, feature_table)
+        self.feature = FeatureHandler(self.config_db)
 
     def aaa_handler(self, key, data):
         self.aaacfg.aaa_update(key, data)
@@ -349,32 +403,16 @@ class HostConfigDaemon:
 
         self.iptables.iptables_handler(key, data, add)
 
-    def feature_state_handler(self, key, data):
-        feature_name = key
-        feature_table = self.config_db.get_table('FEATURE')
-        if feature_name not in feature_table.keys():
-            syslog.syslog(syslog.LOG_WARNING, "Feature '{}' not in FEATURE table".format(feature_name))
-            return
-
-        state = feature_table[feature_name]['state']
-        if not state:
-            syslog.syslog(syslog.LOG_WARNING, "Enable state of feature '{}' is None".format(feature_name))
-            return
-
-        # Enable/disable the container service if the feature state was changed from its previous state.
-        if self.cached_feature_states[feature_name] != state:
-            self.cached_feature_states[feature_name] = state
-            self.update_feature_state(feature_name, state, feature_table)
+    def feature_handler(self, key, data):
+        self.feature.handle(key, data)
 
     def start(self):
-        # Update all feature states once upon starting
-        self.update_all_feature_states()
-
+        self.feature.update_all_features_config()
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))
         self.config_db.subscribe('TACPLUS_SERVER', lambda table, key, data: self.tacacs_server_handler(key, data))
         self.config_db.subscribe('TACPLUS', lambda table, key, data: self.tacacs_global_handler(key, data))
         self.config_db.subscribe('LOOPBACK_INTERFACE', lambda table, key, data: self.lpbk_handler(key, data))
-        self.config_db.subscribe('FEATURE', lambda table, key, data: self.feature_state_handler(key, data))
+        self.config_db.subscribe('FEATURE', lambda table, key, data: self.feature_handler(key, data))
         self.config_db.listen()
 
 

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -6,8 +6,6 @@ import signal
 import sys
 import syslog
 
-import swsssdk
-
 from supervisor import childutils
 
 # Each line of this file should specify either one critical process or one
@@ -46,16 +44,6 @@ def get_critical_group_and_process_list():
     return critical_group_list, critical_process_list
 
 def main(argv):
-    container_name = None
-    opts, args = getopt.getopt(argv, "c:", ["container-name="])
-    for opt, arg in opts:
-        if opt in ("-c", "--container-name"):
-            container_name = arg
-
-    if not container_name:
-        syslog.syslog(syslog.LOG_ERR, "Container name not specified. Exiting...")
-        sys.exit(1)
-
     critical_group_list, critical_process_list = get_critical_group_and_process_list()
 
     while True:
@@ -73,32 +61,14 @@ def main(argv):
         if headers['eventname'] == 'PROCESS_STATE_EXITED':
             payload_headers, payload_data = childutils.eventdata(payload + '\n')
 
-            expected = int(payload_headers['expected'])
+            expected_exit = int(payload_headers['expected'])
             processname = payload_headers['processname']
             groupname = payload_headers['groupname']
 
-            # Read the status of auto-restart feature from Config_DB.
-            if container_name != 'database':
-                config_db = swsssdk.ConfigDBConnector()
-                config_db.connect()
-                features_table = config_db.get_table(FEATURE_TABLE_NAME)
-                if not features_table:
-                    syslog.syslog(syslog.LOG_ERR, "Unable to retrieve features table from Config DB. Exiting...")
-                    sys.exit(2)
+            is_critical = processname in critical_process_list or groupname in critical_group_list
 
-                if not features_table.has_key(container_name):
-                    syslog.syslog(syslog.LOG_ERR, "Unable to retrieve feature '{}'. Exiting...".format(container_name))
-                    sys.exit(3)
-
-                restart_feature = features_table[container_name].get('auto_restart')
-                if not restart_feature:
-                    syslog.syslog(syslog.LOG_ERR, "Unable to determine auto-restart feature status for '{}'. Exiting...".format(container_name))
-                    sys.exit(4)
-
-            # If container is database or auto-restart feature is enabled and at the same time
-            # a critical process exited unexpectedly, terminate supervisor
-            if ((container_name == 'database' or restart_feature == 'enabled') and expected == 0 and
-                    (processname in critical_process_list or groupname in critical_group_list)):
+            # If a critical process exited unexpectedly, terminate supervisor
+            if is_critical and not expected_exit:
                 MSG_FORMAT_STR = "Process {} exited unxepectedly. Terminating supervisor..."
                 msg = MSG_FORMAT_STR.format(payload_headers['processname'])
                 syslog.syslog(syslog.LOG_INFO, msg)

--- a/platform/barefoot/docker-syncd-bfn/supervisord.conf
+++ b/platform/barefoot/docker-syncd-bfn/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/broadcom/docker-syncd-brcm/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/cavium/docker-syncd-cavm/supervisord.conf
+++ b/platform/cavium/docker-syncd-cavm/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/centec-arm64/docker-syncd-centec/supervisord.conf
+++ b/platform/centec-arm64/docker-syncd-centec/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/centec/docker-syncd-centec/supervisord.conf
+++ b/platform/centec/docker-syncd-centec/supervisord.conf
@@ -12,7 +12,7 @@ exitcodes=0,3
 events=PROCESS_STATE
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/marvell/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell/docker-syncd-mrvl/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/mellanox/docker-syncd-mlnx/supervisord.conf
+++ b/platform/mellanox/docker-syncd-mlnx/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/nephos/docker-syncd-nephos/supervisord.conf
+++ b/platform/nephos/docker-syncd-nephos/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/vs/docker-gbsyncd-vs/supervisord.conf
+++ b/platform/vs/docker-gbsyncd-vs/supervisord.conf
@@ -12,7 +12,7 @@ exitcodes=0,3
 events=PROCESS_STATE
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name gbsyncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/vs/docker-syncd-vs/supervisord.conf
+++ b/platform/vs/docker-syncd-vs/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=50
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name dhcp_relay
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=50
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name dhcp_relay
+command=/usr/bin/supervisor-proc-exit-listener
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected


### PR DESCRIPTION
Before this change, a process runnning inside every SONiC
container dealt with FEATURE table 'auto_restart' field and
depending on the value decided wether a container has to be
killed or not. If killed service auto restart mechanism
restarts the container. This change moves the logic from
container to the host daemon - hostcfgd.

* hostcfgd refactoring - move feature handling in another class.
* override systemd service Restart= setting from hostcfgd.
* remove code that deals with FEATURE table from supervisor-proc-exit-listener.
* remove default systemd Restart=always.

Signed-off-by: Stepan Blyshchak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Remove the need to deal with container orchestration logic from the container itself. Leave this logic to the orchestrator - host OS.

**- How I did it**

hostcfgd configures 'Restart=' value for systemd service.

**- How to verify it**

```
root@r-tigon-11:/home/admin# sudo config feature autorestart lldp enabled
root@r-tigon-11:/home/admin# show feature status | grep lldp
lldp            enabled   enabled
root@r-tigon-11:/home/admin# docker exec -it lldp pkill -9 lldpd
root@r-tigon-11:/home/admin# docker ps -a | grep lldp
65058396277c        docker-lldp:latest                   "/usr/bin/docker-lld…"   2 days ago          Exited (0) 20 seconds ago                       lldp
root@r-tigon-11:/home/admin# docker ps -a | grep lldp
65058396277c        docker-lldp:latest                   "/usr/bin/docker-lld…"   2 days ago          Up 5 seconds                            lldp
root@r-tigon-11:/home/admin# sudo config feature autorestart lldp disabled
root@r-tigon-11:/home/admin# docker exec -it lldp pkill -9 lldpd
root@r-tigon-11:/home/admin# docker ps -a | grep lldp
65058396277c        docker-lldp:latest                   "/usr/bin/docker-lld…"   2 days ago          Up 35 seconds                           lldp
root@r-tigon-11:/home/admin# docker ps -a | grep lldp
65058396277c        docker-lldp:latest                   "/usr/bin/docker-lld…"   2 days ago          Exited (0) 3 seconds ago                       lldp
root@r-tigon-11:/home/admin# docker ps -a | grep lldp
65058396277c        docker-lldp:latest                   "/usr/bin/docker-lld…"   2 days ago          Exited (0) 39 seconds ago                       lldp
root@r-tigon-11:/home/admin#

```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
