### PR TITLE
[fpm-frr] fix start.sh template paths

### DIFF
--- a/dockers/docker-fpm-frr/start.sh
+++ b/dockers/docker-fpm-frr/start.sh
@@ -6,8 +6,7 @@ mkdir -p /etc/supervisor/conf.d
 CFGGEN_PARAMS=" \
     -d \
     -y /etc/sonic/constants.yml \
-    -t /usr/share/sonic/templates/supervisord/frr_vars.j2 \
-    -t /usr/share/sonic/templates/supervisord/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf \
+    -t /usr/share/sonic/templates/frr_vars.j2 \
     -t /usr/share/sonic/templates/bgpd/bgpd.conf.j2,/etc/frr/bgpd.conf \
     -t /usr/share/sonic/templates/zebra/zebra.conf.j2,/etc/frr/zebra.conf \
     -t /usr/share/sonic/templates/staticd/staticd.conf.j2,/etc/frr/staticd.conf \


### PR DESCRIPTION
There is no /usr/share/sonic/templates/supervisord/ folder
and no supervisord.conf.j2 template.

Signed-off-by: Stepan Blyshchak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
