### PR TITLE
[teamd/patch] do not send LACP PDU if link is down

### DIFF
--- a/src/libteam/patch/0007-Send-LACP-PDU-immediately-if-our-state-changed.patch
+++ b/src/libteam/patch/0007-Send-LACP-PDU-immediately-if-our-state-changed.patch
@@ -1,27 +1,41 @@
-From 780cc967a5544d3ab6f43cba4076b5e0dbb48395 Mon Sep 17 00:00:00 2001
+From 9a6f63427e843683234a8ea21435b9c69a7a418c Mon Sep 17 00:00:00 2001
 From: Pavel Shirshov <pavelsh@microsoft.com>
 Date: Tue, 3 Mar 2020 13:01:14 -0800
 Subject: [PATCH] Send LACP PDU immediately if our state changed
 
+Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>
 ---
- teamd/teamd_runner_lacp.c | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ teamd/teamd_runner_lacp.c | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
-index fa732ba..55abe88 100644
+index a1d487c..3e733ec 100644
 --- a/teamd/teamd_runner_lacp.c
 +++ b/teamd/teamd_runner_lacp.c
-@@ -1019,8 +1019,7 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
+@@ -963,6 +963,7 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
+ 			       enum lacp_port_state new_state)
+ {
+ 	int err;
++	bool linkup = team_is_port_link_up(lacp_port->tdport->team_port);
+ 
+ 	if (new_state == lacp_port->state)
+ 		return 0;
+@@ -1019,9 +1020,11 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
  		return err;
  
  	lacp_port_actor_update(lacp_port);
 -	if (lacp_port->periodic_on)
 -		return 0;
+-	return lacpdu_send(lacp_port);
 +
- 	return lacpdu_send(lacp_port);
++	if (linkup)
++		err = lacpdu_send(lacp_port);
++
++ 	return err;
  }
  
-@@ -1138,9 +1137,10 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+ static enum lacp_port_state lacp_port_get_state(struct lacp_port *lacp_port)
+@@ -1138,9 +1141,10 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
  	if (err)
  		return err;
  
@@ -34,6 +48,3 @@ index fa732ba..55abe88 100644
  		   sizeof(struct lacpdu_info))) {
  		err = lacpdu_send(lacp_port);
  		if (err)
--- 
-2.17.1.windows.2
-


### PR DESCRIPTION
Otherwise the lacp_port_set_state() returns error when called from
lacp_port_link_update() and lead to not up-to-date cache in
lacp_port->__link_last. This can happen when member flapping happens.
When this issue happens the condition comparing lacp_port->__link_last
to current linkup in lacp_port_link_update() will not pass and member
will never get out of deselected state unless it is flapped again.

This is done as a fix in patch maintained by SONiC but planned to be
upstreamed in libteam as well. Currently we cannot simply propose this
fix in libteam and use libteam master as of important bug fix revert in
jpirko/libteam 61efd6de2fbb8ee077863ee5a355ac3dfd9365b9.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

