### PR TITLE
[buildsystem] install 3rd party debian packages in base OS during build

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -274,6 +274,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            BUILD_LOG_TIMESTAMP=$(BUILD_LOG_TIMESTAMP) \
                            SONIC_ENABLE_IMAGE_SIGNATURE=$(ENABLE_IMAGE_SIGNATURE) \
                            ENABLE_HOST_SERVICE_ON_START=$(ENABLE_HOST_SERVICE_ON_START) \
+                           INSTALL_THIRD_PARTY_DEBS=$(INSTALL_THIRD_PARTY_DEBS) \
                            SLAVE_DIR=$(SLAVE_DIR) \
                            $(SONIC_OVERRIDE_BUILD_VARS)
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -727,7 +727,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT sonic-package-manager install --from-tarball
 {% if install_third_party_debs -%}
 TEMP_DIR="$(sudo LANG=C chroot $FILESYSTEM_ROOT mktemp -d)"
 sudo wget {{ install_third_party_debs.strip().replace(",", " ") }} --directory-prefix="$FILESYSTEM_ROOT/$TEMP_DIR"
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT bash -c "apt-get install -y \"$TEMP_DIR\"/*"
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT bash -c "apt-get install -y $TEMP_DIR/*"
 sudo rm -rf "$FILESYSTEM_ROOT/$TEMP_DIR"
 {% endif -%}
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -725,9 +725,9 @@ sudo LANG=C chroot $FILESYSTEM_ROOT sonic-package-manager install --from-tarball
 {% endfor -%}
 
 {% if install_third_party_debs -%}
-TEMP_DIR="$(sudo LANG=C chroot $FILESYSTEM_ROOT mktemp -d)";
-sudo wget {{ install_third_party_debs.strip().replace(",", " ") }} --directory-prefix="$FILESYSTEM_ROOT/$TEMP_DIR";
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y "$TEMP_DIR/*";
+TEMP_DIR="$(sudo LANG=C chroot $FILESYSTEM_ROOT mktemp -d)"
+sudo wget {{ install_third_party_debs.strip().replace(",", " ") }} --directory-prefix="$FILESYSTEM_ROOT/$TEMP_DIR"
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y "$TEMP_DIR/*"
 sudo rm -rf "$FILESYSTEM_ROOT/$TEMP_DIR"
 {% endif -%}
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -727,7 +727,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT sonic-package-manager install --from-tarball
 {% if install_third_party_debs -%}
 TEMP_DIR="$(sudo LANG=C chroot $FILESYSTEM_ROOT mktemp -d)"
 sudo wget {{ install_third_party_debs.strip().replace(",", " ") }} --directory-prefix="$FILESYSTEM_ROOT/$TEMP_DIR"
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y "$TEMP_DIR/*"
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT bash -c "apt-get install -y \"$TEMP_DIR\"/*"
 sudo rm -rf "$FILESYSTEM_ROOT/$TEMP_DIR"
 {% endif -%}
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -725,11 +725,10 @@ sudo LANG=C chroot $FILESYSTEM_ROOT sonic-package-manager install --from-tarball
 {% endfor -%}
 
 {% if install_third_party_debs -%}
-sudo LANG=C chroot $FILESYSTEM_ROOT bash -c '
-TEMP_DIR="$(mktemp -d);
-wget {{ install_third_party_debs.strip().replace(",", " ") }} --directory-prefix="$TEMP_DIR" || exit 1;
-dpkg --install --recursive "$TEMP_DIR" || exit 1
-'
+TEMP_DIR="$(sudo LANG=C chroot $FILESYSTEM_ROOT mktemp -d)";
+sudo wget {{ install_third_party_debs.strip().replace(",", " ") }} --directory-prefix="$FILESYSTEM_ROOT/$TEMP_DIR";
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y "$TEMP_DIR/*";
+sudo rm -rf "$FILESYSTEM_ROOT/$TEMP_DIR"
 {% endif -%}
 
 sudo umount $FILESYSTEM_ROOT/target

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -724,6 +724,20 @@ sudo LANG=C chroot $FILESYSTEM_ROOT sonic-package-manager install {{ name }}=={{
 sudo LANG=C chroot $FILESYSTEM_ROOT sonic-package-manager install --from-tarball {{ path }} {{ get_install_options(set_owner, enabled) }}
 {% endfor -%}
 
+{% if install_third_party_debs -%}
+{% for url in install_third_party_debs.strip().split(',') -%}
+sudo LANG=C chroot $FILESYSTEM_ROOT bash -c '
+TEMP_DEB="$(mktemp)"
+curl "{{ url }}" -o "${TEMP_DEB}" || {
+    exit 1;
+}
+dpkg -i "${TEMP_DEB}" || {
+    exit 1;
+}
+rm -f "${TEMP_DEB}"'
+{% endfor -%}
+{% endif -%}
+
 sudo umount $FILESYSTEM_ROOT/target
 sudo rm -r $FILESYSTEM_ROOT/target
 if [ $MULTIARCH_QEMU_ENVIRON == y ]; then

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -725,17 +725,11 @@ sudo LANG=C chroot $FILESYSTEM_ROOT sonic-package-manager install --from-tarball
 {% endfor -%}
 
 {% if install_third_party_debs -%}
-{% for url in install_third_party_debs.strip().split(',') -%}
 sudo LANG=C chroot $FILESYSTEM_ROOT bash -c '
-TEMP_DEB="$(mktemp)"
-curl "{{ url }}" -o "${TEMP_DEB}" || {
-    exit 1;
-}
-dpkg -i "${TEMP_DEB}" || {
-    exit 1;
-}
-rm -f "${TEMP_DEB}"'
-{% endfor -%}
+TEMP_DIR="$(mktemp -d);
+wget {{ install_third_party_debs.strip().replace(",", " ") }} --directory-prefix="$TEMP_DIR" || exit 1;
+dpkg --install --recursive "$TEMP_DIR" || exit 1
+'
 {% endif -%}
 
 sudo umount $FILESYSTEM_ROOT/target

--- a/rules/config
+++ b/rules/config
@@ -194,4 +194,4 @@ REGISTRY_SERVER=sonicdev-microsoft.azurecr.io
 # This variable is used to install 3rd party debian packages in base SONiC OS.
 # A comma-seperated list of URLs to fetch debian packages from is expected.
 # NOTE: debian packages are installed in the order they are defined.
-INSTALL_THIRD_PARTY_DEBS ?=
+INSTALL_THIRD_PARTY_DEBS ?= ""

--- a/rules/config
+++ b/rules/config
@@ -190,3 +190,8 @@ SONIC_VERSION_CONTROL_COMPONENTS ?= none
 # ENABLE_DOCKER_BASE_PULL = y
 REGISTRY_PORT=443
 REGISTRY_SERVER=sonicdev-microsoft.azurecr.io
+
+# This variable is used to install 3rd party debian packages in base SONiC OS.
+# A comma-seperated list of URLs to fetch debian packages from is expected.
+# NOTE: debian packages are installed in the order they are defined.
+INSTALL_THIRD_PARTY_DEBS ?=

--- a/slave.mk
+++ b/slave.mk
@@ -261,6 +261,7 @@ $(info "INCLUDE_MACSEC"                  : "$(INCLUDE_MACSEC)")
 $(info "TELEMETRY_WRITABLE"              : "$(TELEMETRY_WRITABLE)")
 $(info "PDDF_SUPPORT"                    : "$(PDDF_SUPPORT)")
 $(info "MULTIARCH_QEMU_ENVIRON"          : "$(MULTIARCH_QEMU_ENVIRON)")
+$(info "INSTALL_THIRD_PARTY_DEBS"        : "$(INSTALL_THIRD_PARTY_DEBS)")
 $(info )
 else
 $(info SONiC Build System for $(CONFIGURED_PLATFORM):$(CONFIGURED_ARCH))
@@ -1018,6 +1019,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	# Exported variables are used by sonic_debian_extension.sh
 	export installer_start_scripts="$(foreach docker, $($*_DOCKERS),$(addsuffix .sh, $($(docker:-dbg.gz=.gz)_CONTAINER_NAME)))"
 	export feature_vs_image_names="$(foreach docker, $($*_DOCKERS), $(addsuffix :, $($(docker:-dbg.gz=.gz)_CONTAINER_NAME):$(docker:-dbg.gz=.gz)))"
+	export install_third_party_debs="$(INSTALL_THIRD_PARTY_DEBS)"
 
 	# Marks template services with an "@" according to systemd convention
 	# If the $($docker)_TEMPLATE) variable is set, the service will be treated as a template


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To allow installing some 3rd party debian packages during build time.

#### How I did it

Added a build time parameter INSTALL_THIRD_PARTY_DEBS.

#### How to verify it

```
INSTALL_THIRD_PARTY_DEBS="https://some.host/some.deb" make target/sonic-mellanox.bin
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

