### PR TITLE
[hostcfgd] differentiate between UnitFileState and UnitFilePreset

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -236,23 +236,38 @@ class FeatureHandler(object):
 
         return feature_names, feature_suffixes
 
+    def get_systemd_unit_state(self, unit):
+        """ Returns service configuration """
+
+        cmd = "sudo systemctl show {} --property UnitFileState".format(unit)
+        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            syslog.syslog(syslog.LOG_ERR, "Failed to get status of {}: rc={} stderr={}".format(unit, proc.returncode, stderr))
+            return 'invalid'  # same as systemd's "invalid indicates that it could not be determined whether the unit file is enabled".
+
+        props = dict([line.split("=") for line in stdout.decode().strip().splitlines()])
+        return props['UnitFileState']
+
+
     def enable_feature(self, feature):
         cmds = []
         feature_names, feature_suffixes = self.get_feature_attribute(feature)
         for feature_name in feature_names:
             # Check if it is already enabled, if yes skip the system call
-            cmd = "sudo systemctl status {}.{} | grep Loaded".format(feature_name, feature_suffixes[-1])
-            proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = proc.communicate()
-            if "enabled" in str(stdout):
+            unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
+            if unit_file_state == "enabled":
                 continue
 
             for suffix in feature_suffixes:
                 cmds.append("sudo systemctl unmask {}.{}".format(feature_name, suffix))
+
             # If feature has timer associated with it, start/enable corresponding systemd .timer unit
             # otherwise, start/enable corresponding systemd .service unit
+
             cmds.append("sudo systemctl enable {}.{}".format(feature_name, feature_suffixes[-1]))
             cmds.append("sudo systemctl start {}.{}".format(feature_name, feature_suffixes[-1]))
+
             for cmd in cmds:
                 syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
                 try:
@@ -267,10 +282,8 @@ class FeatureHandler(object):
         feature_names, feature_suffixes = self.get_feature_attribute(feature)
         for feature_name in feature_names:
             # Check if it is already disabled, if yes skip the system call
-            cmd = "sudo systemctl status {}.{} | grep Loaded".format(feature_name, feature_suffixes[-1])
-            proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = proc.communicate()
-            if "disabled" in str(stdout) or "masked" in str(stdout):
+            unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
+            if unit_file_state in ("disabled", "masked"):
                 continue
 
             for suffix in reversed(feature_suffixes):

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -247,7 +247,7 @@ class FeatureHandler(object):
             return 'invalid'  # same as systemd's "invalid indicates that it could not be determined whether the unit file is enabled".
 
         props = dict([line.split("=") for line in stdout.decode().strip().splitlines()])
-        return props['UnitFileState']
+        return props["UnitFileState"]
 
 
     def enable_feature(self, feature):


### PR DESCRIPTION
It can be that service is not enabled but UnitFilePreset=enabled (case
for Application Extension):

```
    Loaded: loaded (/lib/systemd/system/cpu-report.service; disabled; vendor preset: enabled)
```

This makes existing logic skip enabling the service.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To fix an issue when a 3rd party package cannot be started by hostcfgd.

#### How I did it

Check explicitely for UnitFileState.

#### How to verify it

Ran UT & ran it on the switch.
Installed 3rd party package and enabled it in config db, verified feature can start.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

