### PR TITLE
[slave.mk] fix error: recursive variable references itself.

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -230,7 +230,7 @@ MAKEFLAGS += -j $(SONIC_BUILD_JOBS)
 export SONIC_CONFIG_MAKE_JOBS
 
 ifeq ($(CONFIGURED_PLATFORM),vs)
-export BUILD_MULTIASIC_KVM=$(BUILD_MULTIASIC_KVM)
+export BUILD_MULTIASIC_KVM
 endif
 
 ###############################################################################


### PR DESCRIPTION
Fix issue:

```
stepanb@9091511f691b:/sonic$ make -f slave.mk list
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "vs"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "12"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"SONIC_BUFFER_MODEL"              : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"NO_PROXY"                        : ""
"ENABLE_ZTP"                      : ""
"INCLUDE_PDE"                     : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : ""
"BUILD_LOG_TIMESTAMP"             : "none"
"SONIC_IMAGE_VERSION"             : "master.0-dirty-"
"BLDENV"                          : "buster"
"VS_PREPARE_MEM"                  : "yes"
"INCLUDE_MGMT_FRAMEWORK"          : "y"
"INCLUDE_ICCPD"                   : "n"
"INCLUDE_SYSTEM_TELEMETRY"        : "y"
"ENABLE_HOST_SERVICE_ON_START"    : "n"
"INCLUDE_RESTAPI"                 : "n"
"INCLUDE_SFLOW"                   : "y"
"INCLUDE_NAT"                     : "y"
"INCLUDE_DHCP_RELAY"              : "y"
"INCLUDE_KUBERNETES"              : "n"
"INCLUDE_MACSEC"                  : "y"
"INCLUDE_MUX"                     : "y"
"TELEMETRY_WRITABLE"              : ""
"ENABLE_AUTO_TECH_SUPPORT"        : "y"
"PDDF_SUPPORT"                    : "y"
"MULTIARCH_QEMU_ENVIRON"          : ""
"SONIC_VERSION_CONTROL_COMPONENTS": "none"
slave.mk:234: *** Recursive variable 'BUILD_MULTIASIC_KVM' references itself (eventually).  Stop.
```

Signed-off-by: Stepan Blyshchak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To fix the above error when running make slave.mk with PLATFORM=vs.

#### How I did it

Instead of:
```
export BUILD_MULTIASIC_KVM=$(BUILD_MULTIASIC_KVM)
```
do just the export:
```
export BUILD_MULTIASIC_KVM
```
BUILD_MULTIASIC_KVM is already defined to be either empty, or from rules/config or from the environment - from Makefile.work. No need to dereference the variable in the export statement.

#### How to verify it

```
PLATFORM=vs make -f slave.mk list # verify no error and BUILD_MULTIASIC_KVM is empty in the output
PLATFORM=vs BUILD_MULTIASIC_KVM=y make -f slave.mk list # verify no error and BUILD_MULTIASIC_KVM is set to y in the output
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

