### PR TITLE
[sonic-yang] fix the feature state type

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1280,6 +1280,15 @@
                 "high_mem_alert": "disabled",
                 "state": "enabled",
                 "set_owner": "kube"
+            },
+            "dhcp_relay": {
+                "auto_restart": "enabled",
+                "has_global_scope": "false",
+                "has_per_asic_scope": "true",
+                "has_timer": "false",
+                "high_mem_alert": "disabled",
+                "state": "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}",
+                "set_owner": "kube"
             }
         },
         "DHCP_RELAY": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/feature.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/feature.json
@@ -2,11 +2,6 @@
     "FEATURE_WITH_CORRECT_VALUES": {
         "desc": "CONFIG FEATURE TABLE WITH ALL THE CORRECT VALUES"
     },
-    "FEATURE_WITH_INVALID_STATE" : {
-        "desc": "Referring invalid feature state.",
-        "eStrKey": "Pattern",
-        "eStr": ["enabled|disabled|always_enabled|always_disabled"]
-    },
     "FEATURE_WITH_INVALID_BOOLEAN_TYPE" : {
         "desc": "Referring invalid feature boolean types.",
         "eStrKey": "Pattern",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/feature.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/feature.json
@@ -47,23 +47,15 @@
                         "has_global_scope": "false",
                         "has_per_asic_scope": "true",
                         "set_owner": "kube"
-                    }
-                ]
-            }
-        }
-    },
-    "FEATURE_WITH_INVALID_STATE": {
-        "sonic-feature:sonic-feature": {
-            "sonic-feature:FEATURE": {
-                "FEATURE_LIST": [
+                    },
                     {
-                        "name": "database",
-                        "state": "dontcare",
-                        "auto_restart": "always_enabled",
+                        "name": "dhcp_relay",
+                        "state": "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}",
+                        "auto_restart": "disabled",
                         "has_timer": "false",
-                        "has_global_scope": "true",
+                        "has_global_scope": "false",
                         "has_per_asic_scope": "true",
-                        "set_owner": "local"
+                        "set_owner": "kube"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-feature.yang
+++ b/src/sonic-yang-models/yang-models/sonic-feature.yang
@@ -13,9 +13,7 @@ module sonic-feature{
 
     typedef feature-state {
         description "configuration to set the feature running state";
-        type string {
-            pattern "enabled|disabled|always_enabled|always_disabled";
-        }
+        type string;
     }
 
     typedef feature-owner {


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The feature state can be a jinja template, like in this file - https://github.com/Azure/sonic-buildimage/blob/master/files/build_templates/init_cfg.json.j2#L39.
Without this change it is not possible to validate a configuration file.

#### How I did it

Relaxes the constraint on feature state. Feature state leaf can be any string.

#### How to verify it

Run UT.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

