### PR TITLE
[sairedis] fix incorrect package specified in sairedis rules

### DIFF
--- a/rules/sairedis.mk
+++ b/rules/sairedis.mk
@@ -46,7 +46,7 @@ $(LIBSAIMETADATA_DBG)_RDEPENDS += $(LIBSAIMETADATA)
 $(eval $(call add_derived_package,$(LIBSAIREDIS),$(LIBSAIMETADATA_DBG)))
 
 ifeq ($(ENABLE_PY2_MODULES), n)
-    $(LIBSWSSCOMMON)_BUILD_ENV += DEB_BUILD_PROFILES=nopython2
+    $(LIBSAIREDIS)_BUILD_ENV += DEB_BUILD_PROFILES=nopython2
 endif
 
 # The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}

--- a/rules/syncd.mk
+++ b/rules/syncd.mk
@@ -33,4 +33,8 @@ $(SYNCD_RPC_DBG)_RDEPENDS += $(SYNCD_RPC)
 $(eval $(call add_derived_package,$(SYNCD),$(SYNCD_RPC_DBG)))
 endif
 
+ifeq ($(ENABLE_PY2_MODULES), n)
+    $(SYNCD)_BUILD_ENV += DEB_BUILD_PROFILES=nopython2
+endif
+
 endif


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

