### PR TITLE
[interfaces-config] use systemd unit properties to configure dependen…

### DIFF
--- a/files/image_config/interfaces/interfaces-config.service
+++ b/files/image_config/interfaces/interfaces-config.service
@@ -2,6 +2,7 @@
 Description=Update interfaces configuration
 Requires=updategraph.service
 After=updategraph.service
+Before=networking.service
 BindsTo=sonic.target
 After=sonic.target
 
@@ -12,3 +13,4 @@ ExecStart=/usr/bin/interfaces-config.sh
 
 [Install]
 WantedBy=sonic.target
+RequiredBy=networking.service

--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -1,30 +1,6 @@
 #!/bin/bash
 
-function wait_networking_service_done() {
-    local -i _WDOG_CNT="1"
-    local -ir _WDOG_MAX="30"
-
-    local -r _TIMEOUT="1s"
-
-    while [[ "${_WDOG_CNT}" -le "${_WDOG_MAX}" ]]; do
-        networking_status="$(systemctl is-active networking 2>&1)"
-
-        if [[ "${networking_status}" == active || "${networking_status}" == inactive || "${networking_status}" == failed ]] ; then
-            return
-        fi
-
-        echo "interfaces-config: networking service is running, wait for it done"
-
-        let "_WDOG_CNT++"
-        sleep "${_TIMEOUT}"
-    done
-
-    echo "interfaces-config: networking service is still running after 30 seconds, killing it"
-    systemctl kill networking 2>&1
-}
-
 if [[ $(ifquery --running eth0) ]]; then
-    wait_networking_service_done
     ifdown --force eth0
 fi
 
@@ -62,8 +38,6 @@ done
 
 # Read sysctl conf files again
 sysctl -p /etc/sysctl.d/90-dhcp6-systcl.conf
-
-systemctl restart networking
 
 # Clean-up created files
 rm -f /tmp/ztp_input.json /tmp/ztp_port_data.json


### PR DESCRIPTION
…cy for networking service

When switch boots up it is possible that networking service starts first before interfaces-config and brings eth0 up. For this case there is a syncrhonization mechanism implemented in interfaces-config.sh that will wait for networking service to finish and bring eth0 down and then restart networking service unconditionally at the end. This method works but takes more time for service to become started and blocks swss, teamd, bgp services which delays the restoration for fast and warm boot. The ideal order is: interfaces-config starts first at boot, generates /etc/network/interfaces and then systemd starts networking service. In case of "systemctl restart interfaces-config" systemd brings networking service down, restarts interfaces-config and starts networking service again.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To optimize boot sequence

#### How I did it

Put a dependency configuration in interfaces-config.service file

#### How to verify it

Boot switch with no MGMT_INTERFACE table, verify we get mgmt IP from dhcp.
Boot with MGMT_INTERFACE config, verify we get mgmt IP set statically.
Restart interfaces-config.sh, verify mgmt interface is configured properly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

