### PR TITLE
[nvidia][syncd] remove supervisor_dependent_startup

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx/supervisord.conf.j2
+++ b/platform/mellanox/docker-syncd-mlnx/supervisord.conf.j2
@@ -4,15 +4,6 @@ logfile_maxbytes=1MB
 logfile_backups=2
 nodaemon=true
 
-[eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
-autostart=true
-autorestart=unexpected
-startretries=0
-exitcodes=0,3
-events=PROCESS_STATE
-buffer_size=1024
-
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
@@ -23,21 +14,18 @@ buffer_size=1024
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE
 priority=1
-autostart=false
+autostart=true
 autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-dependent_startup=true
 
 [program:syncd]
 command=/usr/bin/syncd_start.sh
 priority=2
-autostart=false
+autostart=true
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
-dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
 {% if ENABLE_ASAN == "y" %}
 environment=ASAN_OPTIONS="log_path=/var/log/asan/syncd-asan.log{{ asan_extra_options }}"
 {% endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Dependent startup introduces delays to starting daemons, affecting boot performance.

#### How I did it

Removed dependent startup configuration.

#### How to verify it

Measure fast reboot control plane down time.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

