### PR TITLE
[frr] fix default zebra config not inserted into empty zebra.conf

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -46,7 +46,8 @@ write_default_zebra_config()
     FILE_NAME=${1}
 
     grep -q '^no fpm use-next-hop-groups' $FILE_NAME || {
-        sed -i '1i no fpm use-next-hop-groups\nfpm address 127.0.0.1' $FILE_NAME
+        echo "no fpm use-next-hop-groups" >> $FILE_NAME
+        echo "fpm address 127.0.0.1" >> $FILE_NAME
     }
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

If zebra.conf is cleared:

```
for f in /etc/sonic/frr/*.conf; do cp /dev/null $f; done
```

The following line:

```
sed -i '1i no fpm use-next-hop-groups\nfpm address 127.0.0.1' $FILE_NAME
```

will not insert default zebra configuration as there is no first line.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Replace ```sed``` with simple ```echo``` commands

#### How to verify it

Configure ```split``` mode. Clear FRR configuration files. Reboot the switch and verify default zebra configuration is applied.
Write some configuration into zebra.conf and reboot. Verify that default and user zebra configuration is present in /etc/frr/zebra.conf.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

