### PR TITLE
Revert bgp suppress fib pending

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -70,7 +70,6 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 {% block bgp_init %}
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 {% if (DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('subtype' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['subtype'].lower() == 'dualtor') %}

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -30,7 +30,7 @@ stderr_logfile=syslog
 dependent_startup=true
 
 [program:zebra]
-command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M dplane_fpm_nl -M snmp --asic-offload=notify_on_offload
+command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M dplane_fpm_nl -M snmp
 priority=4
 autostart=false
 autorestart=false

--- a/platform/vs/docker-sonic-vs/supervisord.conf.j2
+++ b/platform/vs/docker-sonic-vs/supervisord.conf.j2
@@ -164,7 +164,7 @@ environment=ASAN_OPTIONS="log_path=/var/log/asan/teammgrd-asan.log{{ asan_extra_
 {% endif %}
 
 [program:zebra]
-command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M dplane_fpm_nl --asic-offload=notify_on_offload
+command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M dplane_fpm_nl
 priority=13
 autostart=false
 autorestart=false

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -305,11 +305,10 @@ class BGPPeerMgrBase(Manager):
         :return: True if no errors, False if there are errors
         """
         bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
-        enable_bgp_suppress_fib_pending_cmd = 'bgp suppress-fib-pending'
         if vrf == 'default':
-            cmd = ('router bgp %s\n %s\n' % (bgp_asn, enable_bgp_suppress_fib_pending_cmd)) + cmd
+            cmd = ('router bgp %s\n' % bgp_asn) + cmd
         else:
-            cmd = ('router bgp %s vrf %s\n %s\n' % (bgp_asn, vrf, enable_bgp_suppress_fib_pending_cmd)) + cmd
+            cmd = ('router bgp %s vrf %s\n' % (bgp_asn, vrf)) + cmd
         self.cfg_mgr.push(cmd)
         return True
 

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -55,7 +55,6 @@ route-map HIDE_INTERNAL permit 20
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -34,7 +34,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/base.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/base.conf
@@ -12,7 +12,6 @@ ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -34,7 +34,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults_router_id.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults_router_id.conf
@@ -34,7 +34,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/ipv6_lo.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/ipv6_lo.conf
@@ -14,7 +14,6 @@ ipv6 prefix-list PL_LoopbackV6 permit fc00::1/128
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/lo0_ipv6_only.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/lo0_ipv6_only.conf
@@ -32,7 +32,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/lo0_ipv6_only_router_id.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/lo0_ipv6_only_router_id.conf
@@ -32,7 +32,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis.conf
@@ -34,7 +34,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis_ipv6_lo4096.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis_ipv6_lo4096.conf
@@ -34,7 +34,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis_ipv6_lo4096_router_id.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis_ipv6_lo4096_router_id.conf
@@ -34,7 +34,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis_router_id.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis_router_id.conf
@@ -34,7 +34,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
@@ -34,7 +34,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -71,7 +71,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 55555
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -43,7 +43,6 @@ backend_device_types = ['BackEndToRRouter', 'BackEndLeafRouter']
 console_device_types = ['MgmtTsToR']
 dhcp_server_enabled_device_types = ['BmcMgmtToRRouter']
 mgmt_device_types = ['BmcMgmtToRRouter', 'MgmtToRRouter', 'MgmtTsToR']
-leafrouter_device_types = ['LeafRouter']
 
 # Counters disabled on management devices
 mgmt_disabled_counters = ["BUFFER_POOL_WATERMARK", "PFCWD", "PG_DROP", "PG_WATERMARK", "PORT_BUFFER_DROP", "QUEUE", "QUEUE_WATERMARK"]
@@ -2173,10 +2172,6 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     # Disable unsupported counters on management devices
     if current_device and current_device['type'] in mgmt_device_types:
         results["FLEX_COUNTER_TABLE"] = {counter: {"FLEX_COUNTER_STATUS": "disable"} for counter in mgmt_disabled_counters}
-
-    # Enable bgp-suppress-fib by default for leafrouter
-    if current_device and current_device['type'] in leafrouter_device_types:
-        results['DEVICE_METADATA']['localhost']['suppress-fib-pending'] = 'enabled'
 
     return results
 

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -42,7 +42,6 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.0/27
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -53,7 +53,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_dualtor.conf
@@ -42,7 +42,6 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.0/27
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
   coalesce-time 10000

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -53,7 +53,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -62,7 +62,6 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.0/27
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
@@ -58,7 +58,6 @@ ip prefix-list PL_LoopbackV4 permit 4.0.0.0/32
 router bgp 4000
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -42,7 +42,6 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -53,7 +53,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_dualtor.conf
@@ -42,7 +42,6 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
   coalesce-time 10000

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -53,7 +53,6 @@ route-map HIDE_INTERNAL permit 10
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -62,7 +62,6 @@ ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
 router bgp 65100
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
@@ -58,7 +58,6 @@ ip prefix-list PL_LoopbackV4 permit 4.0.0.0/32
 router bgp 4000
 !
   bgp log-neighbor-changes
-  bgp suppress-fib-pending
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -132,16 +132,6 @@
     "DEVICE_METADATA_ADVERTISE_LO_PREFIX_AS_128": {
         "desc": "Verifying advertising lo prefix as /128."
     },
-    "DEVICE_METADATA_SUPPRESS_PENDING_FIB_ENABLED": {
-        "desc": "Enable bgp-suppress-fib-pending"
-    },
-    "DEVICE_METADATA_SUPPRESS_PENDING_FIB_DISABLED": {
-        "desc": "Disable bgp-suppress-fib-pending"
-    },
-    "DEVICE_METADATA_SUPPRESS_PENDING_FIB_ENABLED_SYNCHRONOUS_MODE_DISABLED": {
-        "desc": "Enable bgp-suppress-fib-pending when synchronous mode is disabled",
-        "eStr": ["ASIC synchronous mode must be enabled in order to enable suppress FIB pending feature"]
-    },
     "DEVICE_METADATA_VALID_RACK_MGMT_MAP": {
         "desc": "Verifying rack_mgmt_map configuration."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -361,36 +361,6 @@
             }
         }
     },
-    "DEVICE_METADATA_SUPPRESS_PENDING_FIB_ENABLED": {
-        "sonic-device_metadata:sonic-device_metadata": {
-            "sonic-device_metadata:DEVICE_METADATA": {
-                "sonic-device_metadata:localhost": {
-                    "synchronous_mode": "enable",
-                    "suppress-fib-pending": "enabled"
-                }
-            }
-        }
-    },
-    "DEVICE_METADATA_SUPPRESS_PENDING_FIB_DISABLED": {
-        "sonic-device_metadata:sonic-device_metadata": {
-            "sonic-device_metadata:DEVICE_METADATA": {
-                "sonic-device_metadata:localhost": {
-                    "synchronous_mode": "disable",
-                    "suppress-fib-pending": "disabled"
-                }
-            }
-        }
-    },
-    "DEVICE_METADATA_SUPPRESS_PENDING_FIB_ENABLED_SYNCHRONOUS_MODE_DISABLED": {
-        "sonic-device_metadata:sonic-device_metadata": {
-            "sonic-device_metadata:DEVICE_METADATA": {
-                "sonic-device_metadata:localhost": {
-                    "synchronous_mode": "disable",
-                    "suppress-fib-pending": "enabled"
-                }
-            }
-        }
-    },
     "DEVICE_METADATA_VALID_RACK_MGMT_MAP": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -212,18 +212,6 @@ module sonic-device_metadata {
                                  By default SONiC advertises /128 subnet prefix in Loopback0 as /64 subnet route";
                 }
 
-                leaf suppress-fib-pending {
-                    description "Enable BGP suppress FIB pending feature. BGP will wait for route FIB installation before announcing routes";
-                    type enumeration {
-                        enum enabled;
-                        enum disabled;
-                    }
-                    default disabled;
-
-                    must "((current() = 'disabled') or (current() = 'enabled' and ../synchronous_mode = 'enable'))" {
-                        error-message "ASIC synchronous mode must be enabled in order to enable suppress FIB pending feature";
-                    }
-                }
                 leaf rack_mgmt_map {
                     type string {
                         length 0..128 {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Revert BGP suppress FIB pending due to unresolved FRR issues in current version

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Revert it

#### How to verify it

Build and run

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

