### PR TITLE
[warmboot] per-namespace /host/warmboot directory

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -662,6 +662,7 @@ start() {
 {%- endif %}
 {%- endif %}
     docker create {{docker_image_run_opt}} \
+        -v /host/warmboot$DEV:/var/warmboot \
 {%- if docker_container_name != "dhcp_server" %}
         --net=$NET \
 {%- endif %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -88,10 +88,10 @@ function getBootType()
 function preStartAction()
 {
 {%- if docker_container_name == "database" %}
-    WARM_DIR=/host/warmboot
+    WARM_DIR=/host/warmboot$DEV
     if [ "$DATABASE_TYPE" != "chassisdb" ]; then
         if [[ ("$BOOT_TYPE" == "warm" || "$BOOT_TYPE" == "fastfast" || "$BOOT_TYPE" == "express" || "$BOOT_TYPE" == "fast")  && -f $WARM_DIR/dump.rdb ]]; then
-            # Load redis content from /host/warmboot/dump.rdb
+            # Load redis content from /host/warmboot$DEV/dump.rdb
             docker cp $WARM_DIR/dump.rdb database$DEV:/var/lib/redis/dump.rdb
         else
             # Create an emtpy file and overwrite any RDB if already there

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -104,7 +104,7 @@ start() {
 
     lock_service_state_change
 
-    mkdir -p /host/warmboot
+    mkdir -p /host/warmboot$DEV
 
     wait_for_database_service
     check_warm_boot
@@ -113,9 +113,9 @@ start() {
 
     if [[ x"$WARM_BOOT" == x"true" ]]; then
         # Leave a mark for syncd scripts running inside docker.
-        touch /host/warmboot/warm-starting
+        touch /host/warmboot$DEV/warm-starting
     else
-        rm -f /host/warmboot/warm-starting
+        rm -f /host/warmboot$DEV/warm-starting
     fi
 
     startplatform


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Use `/host/warmboot$DEV` as warmboot directory in scripts to support Multi-ASIC devices.
$DEV is empty for single-ASIC device - no path change in this case.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add $DEV as a suffix in scripts.

#### How to verify it

Run on Multi-ASIC device.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

